### PR TITLE
Refactor pages to share header script

### DIFF
--- a/contacts/index.html
+++ b/contacts/index.html
@@ -49,81 +49,10 @@
     </section>
   </main>
 
+<script src="/scripts/header.js"></script>
 <script>
-        function loadHeader() {
-            fetch('/header.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    // After loading the header, load the header script
-                    const script = document.createElement('script');
-                    script.src = "/scripts/header.js";
-                    document.body.appendChild(script);
-                });
-        }
-
-        loadHeader();
-    </script>
-    <script>
-        function loadHeader() {
-            fetch('/header.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    initializeMenuToggle();
-                    initializeHeaderOpacity();
-                });
-        }
-
-        loadHeader();
-
-        function initializeMenuToggle() {
-            document.querySelector('.mobile-menu-button').addEventListener('click', toggleMenu);
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            var header = document.querySelector('header');
-            header.addEventListener('mouseover', function() {
-                this.classList.add('hovered');
-                this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-            });
-
-            header.addEventListener('mouseout', function() {
-                this.classList.remove('hovered');
-                handleHeaderOpacity();
-            });
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 1;
-                blurValue = 1;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            var header = document.querySelector('header');
-            if (!header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
-    </script>
+  loadHeader();
+</script>
 </body>
 </html>
 

--- a/contacts/ru/index.html
+++ b/contacts/ru/index.html
@@ -50,66 +50,10 @@
   </main>
 
 
-    <script>
-        function loadHeader() {
-            fetch('/headerru.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    initializeMenuToggle();
-                    initializeHeaderOpacity();
-                });
-        }
-
-        loadHeader();
-
-        function initializeMenuToggle() {
-            document.querySelector('.mobile-menu-button').addEventListener('click', toggleMenu);
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            var header = document.querySelector('header');
-            header.addEventListener('mouseover', function() {
-                this.classList.add('hovered');
-                this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-            });
-
-            header.addEventListener('mouseout', function() {
-                this.classList.remove('hovered');
-                handleHeaderOpacity();
-            });
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 1;
-                blurValue = 1;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            var header = document.querySelector('header');
-            if (!header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
-    </script>
+<script src="/scripts/header.js"></script>
+<script>
+  loadHeader('ru');
+</script>
 </body>
 </html>
 

--- a/filminginkz/index.html
+++ b/filminginkz/index.html
@@ -357,83 +357,9 @@ Kolsai Lakes, often dubbed the "Pearl of the Northern Tien Shan," are nestled wi
 
 
 
+<script src="/scripts/header.js"></script>
 <script>
-       
-
-function loadHeader() {
-            fetch('/header.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    initializeMenuToggle();
-                    initializeHeaderOpacity();
-                });
-        }
-
-        loadHeader();
-
-        function initializeMenuToggle() {
-            document.querySelector('.mobile-menu-button').addEventListener('click', toggleMenu);
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            var header = document.querySelector('header');
-            header.addEventListener('mouseover', function() {
-                this.classList.add('hovered');
-                this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-            });
-
-            header.addEventListener('mouseout', function() {
-                this.classList.remove('hovered');
-                handleHeaderOpacity();
-            });
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 0.85;
-                blurValue = 10;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            var header = document.querySelector('header');
-            if (!header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
+  loadHeader();
 </script>
-<script>
- function loadHeader() {
-            fetch('/header.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    // After loading the header, load the header script
-                    const script = document.createElement('script');
-                    script.src = "/scripts/header.js";
-                    document.body.appendChild(script);
-                });
-        }
-
-        loadHeader();
-
-  </script>
 </body>
 </html>

--- a/filminginkz/ru/index.html
+++ b/filminginkz/ru/index.html
@@ -319,84 +319,9 @@
 
 
 
+<script src="/scripts/header.js"></script>
 <script>
-       
-
-function loadHeader() {
-            fetch('/header.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    initializeMenuToggle();
-                    initializeHeaderOpacity();
-                });
-        }
-
-        loadHeader();
-
-        function initializeMenuToggle() {
-            document.querySelector('.mobile-menu-button').addEventListener('click', toggleMenu);
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            var header = document.querySelector('header');
-            header.addEventListener('mouseover', function() {
-                this.classList.add('hovered');
-                this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-            });
-
-            header.addEventListener('mouseout', function() {
-                this.classList.remove('hovered');
-                handleHeaderOpacity();
-            });
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 0.85;
-                blurValue = 10;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            var header = document.querySelector('header');
-            if (!header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
+  loadHeader('ru');
 </script>
-
-<script>
- function loadHeader() {
-            fetch('/headerru.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    // After loading the header, load the header script
-                    const script = document.createElement('script');
-                    script.src = "/scripts/header.js";
-                    document.body.appendChild(script);
-                });
-        }
-
-        loadHeader();
-
-  </script>
 </body>
 </html>

--- a/globalpartnerships/index.html
+++ b/globalpartnerships/index.html
@@ -192,86 +192,10 @@
         </div>
     </section>  
 </main>
- <script>
-        function loadHeader() {
-            fetch('/header.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    // After loading the header, load the header script
-                    const script = document.createElement('script');
-                    script.src = "/scripts/header.js";
-                    document.body.appendChild(script);
-                });
-        }
-
-        loadHeader();
-    </script>
- <script>
-        function loadHeader() {
-            fetch('/header.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    initializeMenuToggle();
-                    initializeHeaderOpacity();
-                });
-        }
-
-        loadHeader();
-
-        function initializeMenuToggle() {
-            const menuButton = document.querySelector('.mobile-menu-button');
-            if (menuButton) {
-                menuButton.addEventListener('click', toggleMenu);
-            }
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            const header = document.querySelector('header');
-            if (header) {
-                header.addEventListener('mouseover', function() {
-                    this.classList.add('hovered');
-                    this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                    this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-                });
-
-                header.addEventListener('mouseout', function() {
-                    this.classList.remove('hovered');
-                    handleHeaderOpacity();
-                });
-            }
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 1;
-                blurValue = 1;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            const header = document.querySelector('header');
-            if (header && !header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
-    </script>
+<script src="/scripts/header.js"></script>
+<script>
+  loadHeader();
+</script>
 </body>
 </html>
 

--- a/globalpartnerships/ru/index.html
+++ b/globalpartnerships/ru/index.html
@@ -199,75 +199,10 @@
         </div>
     </section>  
 </main>
- <script>
-        function loadHeader() {
-            fetch('/headerru.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    // After loading the header, load the header script
-                    const script = document.createElement('script');
-                    script.src = "/scripts/header.js";
-                    document.body.appendChild(script);
-                });
-        }
-
-        loadHeader();
-    </script>
- <script>
-
-        function initializeMenuToggle() {
-            const menuButton = document.querySelector('.mobile-menu-button');
-            if (menuButton) {
-                menuButton.addEventListener('click', toggleMenu);
-            }
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            const header = document.querySelector('header');
-            if (header) {
-                header.addEventListener('mouseover', function() {
-                    this.classList.add('hovered');
-                    this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                    this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-                });
-
-                header.addEventListener('mouseout', function() {
-                    this.classList.remove('hovered');
-                    handleHeaderOpacity();
-                });
-            }
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 1;
-                blurValue = 1;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            const header = document.querySelector('header');
-            if (header && !header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
-    </script>
+<script src="/scripts/header.js"></script>
+<script>
+  loadHeader('ru');
+</script>
 </body>
 </html>
 

--- a/indiainkz/index.html
+++ b/indiainkz/index.html
@@ -198,70 +198,10 @@ Since then, Maira has consistently participated in the annual IIFTC Conclave, In
     </section>
 </main>
 
-  <script>
-        function loadHeader() {
-            fetch('/header.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                });
-        }
-
-        loadHeader();
-    </script>
-
-    <script>
-        
-
-        function initializeMenuToggle() {
-            document.querySelector('.mobile-menu-button').addEventListener('click', toggleMenu);
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            var header = document.querySelector('header');
-            header.addEventListener('mouseover', function() {
-                this.classList.add('hovered');
-                this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-            });
-
-            header.addEventListener('mouseout', function() {
-                this.classList.remove('hovered');
-                handleHeaderOpacity();
-            });
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 1;
-                blurValue = 1;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            var header = document.querySelector('header');
-            if (!header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
-
-
-    </script>
+<script src="/scripts/header.js"></script>
+<script>
+  loadHeader();
+</script>
 </body>
 </html>
 

--- a/indiainkz/ru/index.html
+++ b/indiainkz/ru/index.html
@@ -174,76 +174,10 @@
 </main>
 
 
-  <script>
-        function loadHeader() {
-            fetch('/headerru.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    // After loading the header, load the header script
-                    const script = document.createElement('script');
-                    script.src = "/scripts/header.js";
-                    document.body.appendChild(script);
-                });
-        }
-
-        loadHeader();
-    </script>
-     <script>
-        
-
-        function initializeMenuToggle() {
-            const menuButton = document.querySelector('.mobile-menu-button');
-            if (menuButton) {
-                menuButton.addEventListener('click', toggleMenu);
-            }
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            const header = document.querySelector('header');
-            if (header) {
-                header.addEventListener('mouseover', function() {
-                    this.classList.add('hovered');
-                    this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                    this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-                });
-
-                header.addEventListener('mouseout', function() {
-                    this.classList.remove('hovered');
-                    handleHeaderOpacity();
-                });
-            }
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 1;
-                blurValue = 1;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            const header = document.querySelector('header');
-            if (header && !header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
-    </script>
+<script src="/scripts/header.js"></script>
+<script>
+  loadHeader('ru');
+</script>
 </body>
 </html>
 

--- a/scripts/header.js
+++ b/scripts/header.js
@@ -1,0 +1,67 @@
+function loadHeader(lang) {
+    const url = lang === 'ru' ? '/headerru.html' : '/header.html';
+    fetch(url)
+        .then(response => response.text())
+        .then(html => {
+            const container = document.getElementById('header-container');
+            if (container) {
+                container.innerHTML = html;
+                initializeMenuToggle();
+                initializeHeaderOpacity();
+            }
+        });
+}
+
+function initializeMenuToggle() {
+    const menuButton = document.querySelector('.mobile-menu-button');
+    if (menuButton) {
+        menuButton.addEventListener('click', toggleMenu);
+    }
+}
+
+function toggleMenu() {
+    document.body.classList.toggle('menu-active');
+    const menuButton = document.querySelector('.mobile-menu-button');
+    if (menuButton) {
+        menuButton.classList.toggle('active');
+    }
+}
+
+function initializeHeaderOpacity() {
+    window.addEventListener('scroll', handleHeaderOpacity);
+    handleHeaderOpacity();
+
+    const header = document.querySelector('header');
+    if (header) {
+        header.addEventListener('mouseover', function () {
+            this.classList.add('hovered');
+            this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
+            this.style.backdropFilter = 'blur(10px)';
+        });
+
+        header.addEventListener('mouseout', function () {
+            this.classList.remove('hovered');
+            handleHeaderOpacity();
+        });
+    }
+}
+
+function handleHeaderOpacity() {
+    const top = window.pageYOffset || document.documentElement.scrollTop;
+    let opacity = 0;
+    let blurValue = 0;
+
+    if (top <= 50) {
+        opacity = 1;
+        blurValue = 1;
+    } else {
+        opacity = 0.85;
+        blurValue = 10;
+    }
+
+    const header = document.querySelector('header');
+    if (header && !header.classList.contains('hovered')) {
+        header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
+        header.style.backdropFilter = `blur(${blurValue}px)`;
+    }
+}

--- a/services/index.html
+++ b/services/index.html
@@ -69,67 +69,10 @@
     </div>
 </section>
 
-    <script>
-        
-
-        function initializeMenuToggle() {
-            document.querySelector('.mobile-menu-button').addEventListener('click', toggleMenu);
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            var header = document.querySelector('header');
-            header.addEventListener('mouseover', function() {
-                this.classList.add('hovered');
-                this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-            });
-
-            header.addEventListener('mouseout', function() {
-                this.classList.remove('hovered');
-                handleHeaderOpacity();
-            });
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 1;
-                blurValue = 1;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            var header = document.querySelector('header');
-            if (!header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
-    function loadHeader() {
-            fetch('/header.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    initializeMenuToggle();
-                    initializeHeaderOpacity();
-                });
-        }
-
-        loadHeader();
-    </script>
+<script src="/scripts/header.js"></script>
+<script>
+  loadHeader();
+</script>
 </body>
 </html>
 

--- a/services/ru/index.html
+++ b/services/ru/index.html
@@ -68,81 +68,10 @@
 </section>
 
 
-  <script>
-        function loadHeader() {
-            fetch('/headerru.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    // After loading the header, load the header script
-                    const script = document.createElement('script');
-                    script.src = "/scripts/header.js";
-                    document.body.appendChild(script);
-                });
-        }
-
-        loadHeader();
-    </script>
-    <script>
-        function loadHeader() {
-            fetch('/headerru.html')
-                .then(response => response.text())
-                .then(data => {
-                    document.getElementById('header-container').innerHTML = data;
-                    initializeMenuToggle();
-                    initializeHeaderOpacity();
-                });
-        }
-
-        loadHeader();
-
-        function initializeMenuToggle() {
-            document.querySelector('.mobile-menu-button').addEventListener('click', toggleMenu);
-        }
-
-        function toggleMenu() {
-            document.body.classList.toggle('menu-active');
-            document.querySelector('.mobile-menu-button').classList.toggle('active');
-        }
-
-        function initializeHeaderOpacity() {
-            window.addEventListener('scroll', handleHeaderOpacity);
-            handleHeaderOpacity(); // Initial call to set the header state on load
-
-            // Handling header hover effects
-            var header = document.querySelector('header');
-            header.addEventListener('mouseover', function() {
-                this.classList.add('hovered');
-                this.style.backgroundColor = 'rgba(5, 5, 5, 0.95)';
-                this.style.backdropFilter = 'blur(10px)'; // Maximum blur value on hover
-            });
-
-            header.addEventListener('mouseout', function() {
-                this.classList.remove('hovered');
-                handleHeaderOpacity();
-            });
-        }
-
-        function handleHeaderOpacity() {
-            var top = window.pageYOffset || document.documentElement.scrollTop;
-            var opacity = 0;
-            var blurValue = 0;
-
-            if (top <= 50) {
-                opacity = 1;
-                blurValue = 1;
-            } else {
-                opacity = 0.85;
-                blurValue = 10; // Maximum blur value
-            }
-
-            var header = document.querySelector('header');
-            if (!header.classList.contains('hovered')) {
-                header.style.backgroundColor = `rgba(5, 5, 5, ${opacity})`;
-                header.style.backdropFilter = `blur(${blurValue}px)`; // Set the blur value
-            }
-        }
-    </script>
+<script src="/scripts/header.js"></script>
+<script>
+  loadHeader('ru');
+</script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- create `scripts/header.js` with header loading logic
- call `loadHeader()` or `loadHeader('ru')` from all contact, services and filming pages
- remove duplicated inline header code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f13da9884832b88fc15efbdd5e82d