### PR TITLE
Fix mobile menu layering

### DIFF
--- a/header.css
+++ b/header.css
@@ -75,15 +75,15 @@ nav.desktop-menu ul li a:hover {
 }
 
 .mobile-menu {
-    position: fixed;
-    top: 0;
-    left: -100%;
-    width: 100%;
-    height: 100%;
-    background: #000000;
-    transition: left 0.3s ease;
-    z-index: 1000; /* Ensure the menu is below the button */
-    padding-top: 70px; /* Add padding to move menu items below the button */
+  position: fixed;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: #000000;
+  transition: left 0.3s ease;
+  z-index: 1040; /* Place menu above the header but below the button */
+  padding-top: 70px; /* Add padding to move menu items below the button */
 }
 
 .mobile-menu-button.active {


### PR DESCRIPTION
## Summary
- ensure mobile menu sits above header by raising its z-index

## Testing
- `python3 -m http.server 8000` and `curl -I http://localhost:8000/aboutus/`

------
https://chatgpt.com/codex/tasks/task_e_684f27acf328832b839ca8c5ecfb903a